### PR TITLE
Remove unnecessary packages from IDE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ Atom Beautify
 Atom Handlebars
 Atom Jshint
 Atom Prettify
-Angularjs
-Atom Angular
-Atom Bootstrap
 Autocomplete
 Autocomplete +
 Bracket Matcher


### PR DESCRIPTION
Why are these here? 
Angular has nothing to do with meteor